### PR TITLE
Maint/update ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,14 @@ env:
     - USE_DEB=true ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu BEFORE_SCRIPT='./install_minimal_linuxcan.sh'
     - USE_DEB=true ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu BEFORE_SCRIPT='./install_minimal_linuxcan.sh'
     - USE_DEB=true ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu BEFORE_SCRIPT='./install_minimal_linuxcan.sh'
-    - USE_DEB=true ROS_DISTRO="melodic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu BEFORE_SCRIPT='./install_minimal_linuxcan.sh'
-    - USE_DEB=true ROS_DISTRO="melodic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu BEFORE_SCRIPT='./install_minimal_linuxcan.sh'
+    - USE_DEB=true ROS_DISTRO="lunar" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu BEFORE_SCRIPT='./install_minimal_linuxcan.sh'
+    - USE_DEB=true ROS_DISTRO="lunar" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu BEFORE_SCRIPT='./install_minimal_linuxcan.sh'
 
 matrix:
   allow_failures:
     env: USE_DEB=true ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu BEFORE_SCRIPT='./install_minimal_linuxcan.sh'
     env: USE_DEB=true ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu BEFORE_SCRIPT='./install_minimal_linuxcan.sh'
-    env: USE_DEB=true ROS_DISTRO="melodic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu BEFORE_SCRIPT='./install_minimal_linuxcan.sh'
+    env: USE_DEB=true ROS_DISTRO="lunar" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu BEFORE_SCRIPT='./install_minimal_linuxcan.sh'
 
 install:
   git clone https://github.com/ros-industrial/industrial_ci.git .ci_config

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,15 +8,18 @@ notifications:
 
 env:
   matrix:
-    - ROS_DISTRO="indigo" ROS_REPO=ros-shadow-fixed BEFORE_SCRIPT='./install_minimal_linuxcan.sh'
-    - ROS_DISTRO="indigo" ROS_REPO=ros BEFORE_SCRIPT='./install_minimal_linuxcan.sh'
-    - ROS_DISTRO="kinetic" ROS_REPO=ros-shadow-fixed BEFORE_SCRIPT='./install_minimal_linuxcan.sh'
-    - ROS_DISTRO="kinetic" ROS_REPO=ros BEFORE_SCRIPT='./install_minimal_linuxcan.sh'
+    - USE_DEB=true ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu BEFORE_SCRIPT='./install_minimal_linuxcan.sh'
+    - USE_DEB=true ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu BEFORE_SCRIPT='./install_minimal_linuxcan.sh'
+    - USE_DEB=true ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu BEFORE_SCRIPT='./install_minimal_linuxcan.sh'
+    - USE_DEB=true ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu BEFORE_SCRIPT='./install_minimal_linuxcan.sh'
+    - USE_DEB=true ROS_DISTRO="melodic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu BEFORE_SCRIPT='./install_minimal_linuxcan.sh'
+    - USE_DEB=true ROS_DISTRO="melodic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu BEFORE_SCRIPT='./install_minimal_linuxcan.sh'
 
 matrix:
   allow_failures:
-    env: ROS_DISTRO="indigo" ROS_REPO=ros-shadow-fixed BEFORE_SCRIPT='./install_minimal_linuxcan.sh'
-    env: ROS_DISTRO="kinetic" ROS_REPO=ros-shadow-fixed BEFORE_SCRIPT='./install_minimal_linuxcan.sh'
+    env: USE_DEB=true ROS_DISTRO="indigo" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu BEFORE_SCRIPT='./install_minimal_linuxcan.sh'
+    env: USE_DEB=true ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu BEFORE_SCRIPT='./install_minimal_linuxcan.sh'
+    env: USE_DEB=true ROS_DISTRO="melodic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu BEFORE_SCRIPT='./install_minimal_linuxcan.sh'
 
 install:
   git clone https://github.com/ros-industrial/industrial_ci.git .ci_config

--- a/install_minimal_linuxcan.sh
+++ b/install_minimal_linuxcan.sh
@@ -10,7 +10,7 @@ LINLIB_SONAME=liblinlib.so.1
 LINLIB_LIBRARY=liblinlib.so.1.4.0
 
 cd /tmp
-wget https://www.kvaser.com/downloads-kvaser/?d_version_id=1193
+wget https://www.kvaser.com/downloads-kvaser/?d_version_id=1193 -O linuxcan.tar.gz
 tar xvf linuxcan.tar.gz
 cd /tmp/linuxcan
 make canlib linlib

--- a/install_minimal_linuxcan.sh
+++ b/install_minimal_linuxcan.sh
@@ -3,14 +3,14 @@ set -ex
 
 CANLIB_LIBNAME=libcanlib.so
 CANLIB_SONAME=libcanlib.so.1
-CANLIB_LIBRARY=libcanlib.so.1.2.0
+CANLIB_LIBRARY=libcanlib.so.1.4.0
 
 LINLIB_LIBNAME=liblinlib.so
 LINLIB_SONAME=liblinlib.so.1
-LINLIB_LIBRARY=liblinlib.so.1.2.0
+LINLIB_LIBRARY=liblinlib.so.1.4.0
 
 cd /tmp
-wget http://www.kvaser.com/software/7330130980754/V5_20_0/linuxcan.tar.gz
+wget https://www.kvaser.com/downloads-kvaser/?d_version_id=1193
 tar xvf linuxcan.tar.gz
 cd /tmp/linuxcan
 make canlib linlib


### PR DESCRIPTION
Updates .travs.yml to newer format for industrial_ci (this allows for faster builds too). Updates install_minimal_linuxcan.sh to use latest version (5.22) which supports newer kernels. Adds build-test support for ROS Lunar Loggerhead.