### PR TITLE
Test/faster travis build

### DIFF
--- a/install_linuxcan.sh
+++ b/install_linuxcan.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 
-apt-get install -y software-properties-common linux-image-generic linux-headers-generic
+apt-get install -y software-properties-common
 apt-add-repository -y ppa:jwhitleyastuff/linuxcan-dkms
 apt-get update
-apt-get install -y linuxcan-dkms
+apt-get install -y linux-image-generic linux-headers-generic linuxcan-dkms

--- a/install_linuxcan.sh
+++ b/install_linuxcan.sh
@@ -4,4 +4,4 @@ set -ex
 apt-get install -y software-properties-common
 apt-add-repository -y ppa:jwhitleyastuff/linuxcan-dkms
 apt-get update
-apt-get install -y linux-image-generic linux-headers-generic linuxcan-dkms
+apt-get install -y linux-headers-generic linuxcan-dkms


### PR DESCRIPTION
Installation of the kernel modules fails with this build script but we really care more about installing the SDK to build the ROS node and that seems to work fine. I'm OK with this.