### PR TITLE
Revert "Memory Management Improvements and Clean-up"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,10 +21,6 @@ jobs:
             cd ..
             catkin build
       - run:
-          name: Lint
-          command: |
-            catkin bt --no-deps --make-args roslint
-      - run:
           name: Run Tests
           command: |
             cd ..
@@ -52,10 +48,6 @@ jobs:
             cd ..
             catkin build
       - run:
-          name: Lint
-          command: |
-            catkin bt --no-deps --make-args roslint
-      - run:
           name: Run Tests
           command: |
             cd ..
@@ -82,10 +74,6 @@ jobs:
           command: |
             cd ..
             catkin build
-      - run:
-          name: Lint
-          command: |
-            catkin bt --no-deps --make-args roslint
       - run:
           name: Run Tests
           command: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,6 @@ add_definitions(-std=c++11)
 find_package(catkin REQUIRED COMPONENTS
   roscpp
   can_msgs
-  roslint
 )
 
 catkin_package(
@@ -16,7 +15,7 @@ catkin_package(
 )
 
 include_directories(
-  include
+  include/${PROJECT_NAME}
   ${catkin_INCLUDE_DIRS}
 )
 
@@ -39,16 +38,13 @@ target_link_libraries(kvaser_can_bridge
   ${catkin_LIBRARIES}
 )
 
-set(ROSLINT_CPP_OPTS "--filter=-runtime/threadsafe_fn,-build/namespaces,-build/include_what_you_use,-build/c++11")
-roslint_cpp()
-
 install(TARGETS ros_linuxcan
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
-install(DIRECTORY include
+install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
 )
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2019 AutonomouStuff, LLC
+Copyright (c) 2017 AutonomouStuff, LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/include/kvaser_interface/kvaser_interface.h
+++ b/include/kvaser_interface/kvaser_interface.h
@@ -1,81 +1,78 @@
 /*
-* Unpublished Copyright (c) 2009-2019 AutonomouStuff, LLC, All Rights Reserved.
+* Unpublished Copyright (c) 2009-2017 AutonomouStuff, LLC, All Rights Reserved.
 *
-* This file is part of the Kvaser ROS driver which is released under the MIT license.
+* This file is part of the Kvaser ROS 1.0 driver which is released under the MIT license.
 * See file LICENSE included with this software or go to https://opensource.org/licenses/MIT for full license details.
 */
 
-#ifndef KVASER_INTERFACE_KVASER_INTERFACE_H
-#define KVASER_INTERFACE_KVASER_INTERFACE_H
+// Define a class that supports a basic CAN interface that's independent of the hardware and driver library used
+// Different libraries can be created to define all these functions for a specific driver library
 
-// C++ Includes
+#ifndef KVASER_INTERFACE_HPP
+#define KVASER_INTERFACE_HPP
+
+//C++ Includes
 #include <iostream>
-#include <memory>
 
-extern "C"
-{
-#include <canlib.h>
-}
+//OS Includes
+#include <unistd.h>
 
 namespace AS
 {
 namespace CAN
 {
+  enum return_statuses
+  {
+    OK = 0,
+    INIT_FAILED = -1,
+    BAD_PARAM = -2,
+    NO_CHANNELS_FOUND = -3,
+    CHANNEL_CLOSED = -4,
+    NO_MESSAGES_RECEIVED = -5,
+    READ_FAILED = -6,
+    WRITE_FAILED = -7,
+    CLOSE_FAILED = -8
+  };
 
-enum ReturnStatuses
-{
-  OK = 0,
-  INIT_FAILED = -1,
-  BAD_PARAM = -2,
-  NO_CHANNELS_FOUND = -3,
-  CHANNEL_CLOSED = -4,
-  NO_MESSAGES_RECEIVED = -5,
-  READ_FAILED = -6,
-  WRITE_FAILED = -7,
-  CLOSE_FAILED = -8
-};
-
-class KvaserCan
-{
+  class KvaserCan
+  {
   public:
     KvaserCan();
 
     ~KvaserCan();
 
     // Called to pass in parameters and open can link
-    ReturnStatuses open(const int32_t& hardware_id,
-                        const int32_t& circuit_id,
-                        const int32_t& bitrate,
-                        const bool& echo_on = true);
+    return_statuses open(const int& hardware_id,
+                         const int& circuit_id,
+                         const int& bitrate,
+                         const bool& echo_on = true);
 
     // Close the can link
-    ReturnStatuses close();
+    return_statuses close();
 
     // Check to see if the CAN link is open
-    bool isOpen();
+    bool is_open();
 
     // Read a message
-    ReturnStatuses read(int64_t *id,
-                        uint8_t *msg,
-                        uint32_t *size,
-                        bool *extended,
-                        uint64_t *time);
+    return_statuses read(long *id,
+                         unsigned char *msg,
+                         unsigned int *size,
+                         bool *extended,
+                         unsigned long *time);
 
     // Send a message
-    ReturnStatuses write(const int64_t& id,
-                         uint8_t *msg,
-                         const uint32_t& size,
-                         const bool& extended);
+    return_statuses write(const long& id,
+                          unsigned char *msg,
+                          const unsigned int& size,
+                          const bool& extended);
 
   private:
-    std::unique_ptr<CanHandle> handle;
+    void *handle;
     bool on_bus;
-};
+  };
 
-// Converts error messages to human-readable strings
-std::string returnStatusDesc(const ReturnStatuses& ret);
-
-}  // namespace CAN
-}  // namespace AS
-
-#endif  // KVASER_INTERFACE_KVASER_INTERFACE_H
+  // Converts error messages to human-readable strings
+  std::string return_status_desc(const return_statuses& ret);
+}
+}
+#endif

--- a/package.xml
+++ b/package.xml
@@ -15,8 +15,6 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>roslint</build_depend>
-
   <depend>roscpp</depend>
   <depend>can_msgs</depend>
 </package>

--- a/src/kvaser_can_bridge.cpp
+++ b/src/kvaser_can_bridge.cpp
@@ -1,7 +1,7 @@
 /*
-* Unpublished Copyright (c) 2009-2019 AutonomouStuff, LLC, All Rights Reserved.
+* Unpublished Copyright (c) 2009-2017 AutonomouStuff, LLC, All Rights Reserved.
 *
-* This file is part of the Kvaser ROS driver which is released under the MIT license.
+* This file is part of the Kvaser ROS 1.0 driver which is released under the MIT license.
 * See file LICENSE included with this software or go to https://opensource.org/licenses/MIT for full license details.
 */
 
@@ -10,7 +10,7 @@
 #include <chrono>
 
 #include <ros/ros.h>
-#include <kvaser_interface/kvaser_interface.h>
+#include <kvaser_interface.h>
 #include <can_msgs/Frame.h>
 
 using namespace AS::CAN;
@@ -25,34 +25,33 @@ ros::Publisher can_tx_pub;
 
 void can_read()
 {
-  int64_t id;
-  uint8_t msg[8] = {};  // zero-initialize array
-  uint32_t size;
+  long id;
+  uint8_t msg[8] = {}; //zero-initialize array
+  unsigned int size;
   bool extended;
-  uint64_t t;
+  unsigned long t;
 
   const std::chrono::milliseconds loop_pause = std::chrono::milliseconds(10);
   bool keep_going = true;
 
-  // Set local to global value before looping.
+  //Set local to global value before looping.
   keep_going_mut.lock();
   keep_going = global_keep_going;
   keep_going_mut.unlock();
 
-  ReturnStatuses ret;
+  return_statuses ret;
 
   while (keep_going)
   {
     std::chrono::system_clock::time_point next_time = std::chrono::system_clock::now();
     next_time += loop_pause;
 
-    if (!can_reader.isOpen())
+    if (!can_reader.is_open())
     {
       ret = can_reader.open(hardware_id, circuit_id, bit_rate, false);
 
       if (ret != OK)
-        ROS_ERROR_THROTTLE(0.5, "Kvaser CAN Interface - Error opening reader: %d - %s",
-          ret, returnStatusDesc(ret).c_str());
+        ROS_ERROR_THROTTLE(0.5, "Kvaser CAN Interface - Error opening reader: %d - %s", ret, return_status_desc(ret).c_str());
     }
     else
     {
@@ -69,54 +68,47 @@ void can_read()
       }
 
       if (ret != NO_MESSAGES_RECEIVED)
-        ROS_WARN_THROTTLE(0.5, "Kvaser CAN Interface - Error reading CAN message: %d - %s",
-          ret, returnStatusDesc(ret).c_str());
+        ROS_WARN_THROTTLE(0.5, "Kvaser CAN Interface - Error reading CAN message: %d - %s", ret, return_status_desc(ret).c_str());
     }
 
     std::this_thread::sleep_until(next_time);
 
-    // Set local to global immediately before next loop.
+    //Set local to global immediately before next loop.
     keep_going_mut.lock();
     keep_going = global_keep_going;
     keep_going_mut.unlock();
   }
 
-  if (can_reader.isOpen())
+  if (can_reader.is_open())
   {
     ret = can_reader.close();
 
     if (ret != OK)
-      ROS_ERROR_THROTTLE(0.5, "Kvaser CAN Interface - Error closing reader: %d - %s",
-        ret, returnStatusDesc(ret).c_str());
+      ROS_ERROR_THROTTLE(0.5, "Kvaser CAN Interface - Error closing reader: %d - %s", ret, return_status_desc(ret).c_str());
   }
 }
 
 void can_rx_callback(const can_msgs::Frame::ConstPtr& msg)
 {
-  ReturnStatuses ret;
+  return_statuses ret;
 
-  if (!can_writer.isOpen())
+  if (!can_writer.is_open())
   {
     // Open the channel.
     ret = can_writer.open(hardware_id, circuit_id, bit_rate, false);
 
     if (ret != OK)
     {
-      ROS_ERROR_THROTTLE(0.5, "Kvaser CAN Interface - Error opening writer: %d - %s",
-        ret, returnStatusDesc(ret).c_str());
+      ROS_ERROR_THROTTLE(0.5, "Kvaser CAN Interface - Error opening writer: %d - %s", ret, return_status_desc(ret).c_str());
     }
   }
 
-  if (can_writer.isOpen())
+  if (can_writer.is_open())
   {
-    ret = can_writer.write(msg->id,
-                           const_cast<unsigned char*>(&(msg->data[0])),
-                           msg->dlc,
-                           msg->is_extended);
+    ret = can_writer.write(msg->id, const_cast<unsigned char*>(&(msg->data[0])), msg->dlc, msg->is_extended);
 
     if (ret != OK)
-      ROS_WARN_THROTTLE(0.5, "Kvaser CAN Interface - CAN send error: %d - %s",
-        ret, returnStatusDesc(ret).c_str());
+      ROS_WARN_THROTTLE(0.5, "Kvaser CAN Interface - CAN send error: %d - %s", ret, return_status_desc(ret).c_str());
   }
 }
 
@@ -135,7 +127,7 @@ int main(int argc, char** argv)
   ros::Subscriber can_rx_sub = n.subscribe("can_rx", 500, can_rx_callback);
 
   // Wait for time to be valid
-  ros::Time::waitForValid();
+  while (ros::Time::now().nsec == 0);
 
   if (priv.getParam("can_hardware_id", hardware_id))
   {
@@ -180,11 +172,10 @@ int main(int argc, char** argv)
 
   ros::waitForShutdown();
 
-  ReturnStatuses ret = can_writer.close();
+  return_statuses ret = can_writer.close();
 
   if (ret != OK)
-    ROS_ERROR("Kvaser CAN Interface - Error closing writer: %d - %s",
-      ret, returnStatusDesc(ret).c_str());
+    ROS_ERROR("Kvaser CAN Interface - Error closing writer: %d - %s", ret, return_status_desc(ret).c_str());
 
   keep_going_mut.lock();
   global_keep_going = false;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,32 +1,48 @@
 /*
-* Unpublished Copyright (c) 2009-2019 AutonomouStuff, LLC, All Rights Reserved.
+* Unpublished Copyright (c) 2009-2017 AutonomouStuff, LLC, All Rights Reserved.
 *
 * This file is part of the Kvaser ROS 1.0 driver which is released under the MIT license.
 * See file LICENSE included with this software or go to https://opensource.org/licenses/MIT for full license details.
 */
 
-#include <kvaser_interface/kvaser_interface.h>
+#include <kvaser_interface.h>
 
-std::string AS::CAN::returnStatusDesc(const ReturnStatuses& ret)
+std::string AS::CAN::return_status_desc(const return_statuses& ret)
 {
   std::string status_string;
 
   if (ret == INIT_FAILED)
+  {
     status_string = "Initialization of the CAN interface failed.";
+  }
   else if (ret == BAD_PARAM)
+  {
     status_string = "A bad parameter was provided to the CAN interface during initalization.";
+  }
   else if (ret == NO_CHANNELS_FOUND)
+  {
     status_string = "No available CAN channels were found.";
+  }
   else if (ret == CHANNEL_CLOSED)
+  {
     status_string = "CAN channel is not currently open.";
+  }
   else if (ret == NO_MESSAGES_RECEIVED)
+  {
     status_string = "No messages were received on the interface.";
+  }
   else if (ret == READ_FAILED)
+  {
     status_string = "A read operation failed on the CAN interface.";
+  }
   else if (ret == WRITE_FAILED)
+  {
     status_string = "A write operation failed on the CAN interface.";
+  }
   else if (ret == CLOSE_FAILED)
+  {
     status_string = "Closing the CAN interface failed.";
+  }
 
   return status_string;
 }


### PR DESCRIPTION
Reverts astuff/kvaser_interface#14

Turns out I had the wrong branch checked out. The new commits cause it to throw this runtime error:

`Kvaser CAN Interface - Error opening reader: -1 - Initialization of the CAN interface failed`