### PR TITLE
Maint/add lint to run tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,10 +21,6 @@ jobs:
             cd ..
             catkin build
       - run:
-          name: Lint
-          command: |
-            catkin bt --no-deps --make-args roslint
-      - run:
           name: Run Tests
           command: |
             source /opt/ros/kinetic/setup.bash
@@ -54,10 +50,6 @@ jobs:
             cd ..
             catkin build
       - run:
-          name: Lint
-          command: |
-            catkin bt --no-deps --make-args roslint
-      - run:
           name: Run Tests
           command: |
             source /opt/ros/lunar/setup.bash
@@ -86,10 +78,6 @@ jobs:
           command: |
             cd ..
             catkin build
-      - run:
-          name: Lint
-          command: |
-            catkin bt --no-deps --make-args roslint
       - run:
           name: Run Tests
           command: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,11 @@ target_link_libraries(kvaser_can_bridge
 set(ROSLINT_CPP_OPTS "--filter=-runtime/threadsafe_fn,-build/namespaces,-build/c++11")
 roslint_cpp()
 
+
+if(CATKIN_ENABLE_TESTING)
+  roslint_add_test()
+endif()
+
 install(TARGETS ros_linuxcan
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}


### PR DESCRIPTION
Adds the linter to the list of tests run by catkin run_tests so build testing will fail if linting fails.