### PR TITLE
No Longer Closes Channel After Read

### DIFF
--- a/src/kvaser_can_bridge.cpp
+++ b/src/kvaser_can_bridge.cpp
@@ -78,12 +78,6 @@ void can_read()
       }
     }
   }
-
-  ret = can_reader.close();
-
-  if (ret != ReturnStatuses::OK)
-    ROS_ERROR_THROTTLE(0.5, "Kvaser CAN Interface - Error closing reader: %d - %s",
-      static_cast<int>(ret), KvaserCanUtils::returnStatusDesc(ret).c_str());
 }
 
 void can_rx_callback(const can_msgs::Frame::ConstPtr& ros_msg)

--- a/src/kvaser_interface.cpp
+++ b/src/kvaser_interface.cpp
@@ -270,10 +270,7 @@ ReturnStatuses KvaserReadCbProxy::registerCb(KvaserCan *canObj, const std::share
 
 void KvaserReadCbProxy::proxyCallback(canNotifyData *data)
 {
-  if (data->eventType == canEVENT_RX)
-  {
-    kvCanObj->readFunc();
-  }
+  kvCanObj->readFunc();
 }
 
 ReturnStatuses KvaserCanUtils::canlibStatToReturnStatus(const int32_t &canlibStat)


### PR DESCRIPTION
In previous versions, we had issues if we didn't close the channel after each read. This appears to now be causing issues and it would only read once before stopping.