### PR TITLE
Msgs with dlc < 8 would fail. Fixed.

### DIFF
--- a/src/kvaser_can_bridge.cpp
+++ b/src/kvaser_can_bridge.cpp
@@ -59,7 +59,7 @@ void can_read()
           can_msgs::Frame can_pub_msg;
           can_pub_msg.header.frame_id = "0";
           can_pub_msg.id = msg.id;
-          can_pub_msg.dlc = msg.data.size();
+          can_pub_msg.dlc = msg.dlc;
           can_pub_msg.is_extended = msg.flags.ext_id;
           can_pub_msg.is_error = msg.flags.error_frame;
           can_pub_msg.is_rtr = msg.flags.rtr;
@@ -105,7 +105,9 @@ void can_rx_callback(const can_msgs::Frame::ConstPtr& ros_msg)
     msg.flags.ext_id = ros_msg->is_extended;
     msg.flags.rtr = ros_msg->is_rtr;
 
-    for (size_t i = 0; i < ros_msg->data.size(); ++i)
+    auto msg_size = KvaserCanUtils::dlcToSize(ros_msg->dlc);
+
+    for (size_t i = 0; i < msg_size; ++i)
     {
       msg.data.push_back(ros_msg->data[i]);
     }


### PR DESCRIPTION
The `data` member of the `can_msgs/Frame` message is currently a fixed-length array of 8 bytes. However, the `AS::CAN::CanMsg` uses a `std::vector<uint8_t>` for it's payload storage so we only allocate the bytes we need. The `write()` function in `kvaser_can_bridge` was passing the DLC correctly but it would always write all 8 bytes to the vector. Since `kvaser_interface` now checks the DLC against the vector size, it would fail if the DLC wasn't 8. This PR fixes this issue and also passes the DLC up directly when reading (since `can_msgs/Frame` doesn't support CAN FD and CAN_FD messages are ignored for ROS publishing right now anyway) instead of using the vector size as the DLC.