### PR TITLE
Empty (valid) messages not being published.

### DIFF
--- a/src/kvaser_can_bridge.cpp
+++ b/src/kvaser_can_bridge.cpp
@@ -48,13 +48,16 @@ void can_read()
 
       if (ret  == ReturnStatuses::OK)
       {
-        // Only publish if msg is not CAN FD.
-        // Also, only publish if msg contains
-        // data, is RTR, or is error frame.
-        if (!msg.flags.fd_msg &&
-            (msg.dlc != 0 ||
-             msg.flags.rtr ||
-             msg.flags.error_frame))
+        // Only publish if msg is not CAN FD,
+        // a wakeup message, a transmit acknowledgement,
+        // a transmit request, a delay notification,
+        // or a failed single-shot.
+        if (!(msg.flags.fd_msg ||
+              msg.flags.wakeup_mode ||
+              msg.flags.tx_ack ||
+              msg.flags.tx_rq ||
+              msg.flags.msg_delayed ||
+              msg.flags.tx_nack))
         {
           can_msgs::Frame can_pub_msg;
           can_pub_msg.header.frame_id = "0";


### PR DESCRIPTION
Messages with DLC = 0 and no data in the payload (but no flags) were not being published. These messages are valid and were being passed by kvaser_interface up to ROS, then silently dropped. This is undesired behavior. The CAN bridge now passes these messages but drops CAN FD (not supported by `can_msgs/Frame`), TX ACK, TX RQ, Message Delay notifications, and TX NACK messages. These are informational-only messages and cannot be correctly represented by `can_msgs/Frame` anyway.