### PR TITLE
Maint/ci use new linuxcan

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,8 +18,6 @@ jobs:
             sudo make
             sudo install -m 644 virtualcan/kvvirtualcan.ko /lib/modules/`uname -r`/updates/dkms/
             sudo virtualcan.sh start
-            cd /usr/src/kvaser-drivers-*/canlib/examples
-            ./listChannels
       - run:
           name: Clone and Run AS Docker Image
           command: |
@@ -67,8 +65,6 @@ jobs:
             sudo make
             sudo install -m 644 virtualcan/kvvirtualcan.ko /lib/modules/`uname -r`/updates/dkms/
             sudo virtualcan.sh start
-            cd /usr/src/kvaser-drivers-*/canlib/examples
-            ./listChannels
       - run:
           name: Clone and Run AS Docker Image
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   kinetic:
     machine:
-      image: circleci/classic:edge
+      image: ubuntu-1604:201903-01
       docker_layer_caching: true
     steps:
       - checkout
@@ -51,7 +51,7 @@ jobs:
 
   melodic:
     machine:
-      image: circleci/classic:edge
+      image: ubuntu-1604:201903-01
       docker_layer_caching: true
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,16 +9,16 @@ jobs:
       - run:
           name: Install Linuxcan on Host
           command: |
-            sudo apt-add-repository -y ppa:jwhitleyastuff/linuxcan-dkms
+            sudo apt-add-repository -y ppa:jwhitleyastuff/kvaser-linux
             sudo apt-get clean && sudo apt-get update -qq && sudo apt-get install dpkg # Fix dpkg bug
-            sudo apt-get install -y linux-headers-`uname -r` linuxcan-dkms
+            sudo apt-get install -y linux-headers-`uname -r` kvaser-drivers-dkms
             sudo depmod
-            cd /usr/src/linuxcan-*
+            cd /usr/src/kvaser-drivers-*
             sudo sed -i 's/#define NR_VIRTUAL_DEV       1/#define NR_VIRTUAL_DEV       3/g' virtualcan/virtualcan.h
             sudo make
             sudo install -m 644 virtualcan/kvvirtualcan.ko /lib/modules/`uname -r`/updates/dkms/
             sudo virtualcan.sh start
-            cd /usr/src/linuxcan-*/canlib/examples
+            cd /usr/src/kvaser-drivers-*/canlib/examples
             ./listChannels
       - run:
           name: Clone and Run AS Docker Image
@@ -58,16 +58,16 @@ jobs:
       - run:
           name: Install Linuxcan on Host
           command: |
-            sudo apt-add-repository -y ppa:jwhitleyastuff/linuxcan-dkms
+            sudo apt-add-repository -y ppa:jwhitleyastuff/kvaser-linux
             sudo apt-get clean && sudo apt-get update -qq && sudo apt-get install dpkg # Fix dpkg bug
-            sudo apt-get install -y linux-headers-`uname -r` linuxcan-dkms
+            sudo apt-get install -y linux-headers-`uname -r` kvaser-drivers-dkms
             sudo depmod
-            cd /usr/src/linuxcan-*
+            cd /usr/src/kvaser-drivers-*
             sudo sed -i 's/#define NR_VIRTUAL_DEV       1/#define NR_VIRTUAL_DEV       3/g' virtualcan/virtualcan.h
             sudo make
             sudo install -m 644 virtualcan/kvvirtualcan.ko /lib/modules/`uname -r`/updates/dkms/
             sudo virtualcan.sh start
-            cd /usr/src/linuxcan-*/canlib/examples
+            cd /usr/src/kvaser-drivers-*/canlib/examples
             ./listChannels
       - run:
           name: Clone and Run AS Docker Image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
             sudo depmod
             cd /usr/src/kvaser-drivers-*
             sudo sed -i 's/#define NR_VIRTUAL_DEV       1/#define NR_VIRTUAL_DEV       3/g' virtualcan/virtualcan.h
-            sudo make
+            sudo make -C virtualcan
             sudo install -m 644 virtualcan/kvvirtualcan.ko /lib/modules/`uname -r`/updates/dkms/
             sudo virtualcan.sh start
       - run:
@@ -62,7 +62,7 @@ jobs:
             sudo depmod
             cd /usr/src/kvaser-drivers-*
             sudo sed -i 's/#define NR_VIRTUAL_DEV       1/#define NR_VIRTUAL_DEV       3/g' virtualcan/virtualcan.h
-            sudo make
+            sudo make -C virtualcan
             sudo install -m 644 virtualcan/kvvirtualcan.ko /lib/modules/`uname -r`/updates/dkms/
             sudo virtualcan.sh start
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,8 +28,8 @@ jobs:
       - run:
           name: Install Linuxcan in Docker
           command: |
-            docker exec test /bin/bash -c "apt-add-repository -y ppa:jwhitleyastuff/linuxcan-dkms && apt update -qq"
-            docker exec test /bin/bash -c "apt install -y linux-headers-generic linuxcan-dkms"
+            docker exec test /bin/bash -c "apt-add-repository -y ppa:jwhitleyastuff/kvaser-linux && apt update -qq"
+            docker exec test /bin/bash -c "apt install -y kvaser-canlib-dev"
       - run:
           name: Set Up ROS in Docker
           command: |
@@ -77,8 +77,8 @@ jobs:
       - run:
           name: Install Linuxcan in Docker
           command: |
-            docker exec test /bin/bash -c "apt-add-repository -y ppa:jwhitleyastuff/linuxcan-dkms && apt update -qq"
-            docker exec test /bin/bash -c "apt install -y linux-headers-generic linuxcan-dkms"
+            docker exec test /bin/bash -c "apt-add-repository -y ppa:jwhitleyastuff/kvaser-linux && apt update -qq"
+            docker exec test /bin/bash -c "apt install -y kvaser-canlib-dev"
       - run:
           name: Set Up ROS in Docker
           command: |
@@ -106,8 +106,8 @@ jobs:
       - run:
           name: Set Up Container
           command: |
-            apt-add-repository -y ppa:jwhitleyastuff/linuxcan-dkms
-            apt-get update -qq && apt-get install -y linux-headers-generic linuxcan-dkms dh-make python-bloom ruby
+            apt-add-repository -y ppa:jwhitleyastuff/kvaser-linux
+            apt-get update -qq && apt-get install -y kvaser-canlib-dev dh-make python-bloom ruby
             gem install --no-rdoc --no-ri deb-s3
             source `find /opt/ros -name setup.bash | sort | head -1`
             rosdep install --from-paths . --ignore-src -y
@@ -132,8 +132,8 @@ jobs:
       - run:
           name: Set Up Container
           command: |
-            apt-add-repository -y ppa:jwhitleyastuff/linuxcan-dkms
-            apt-get update -qq && apt-get install -y linux-headers-generic linuxcan-dkms dh-make python-bloom ruby
+            apt-add-repository -y ppa:jwhitleyastuff/kvaser-linux
+            apt-get update -qq && apt-get install -y kvaser-canlib-dev dh-make python-bloom ruby
             gem install --no-rdoc --no-ri deb-s3
             source `find /opt/ros -name setup.bash | sort | head -1`
             rosdep install --from-paths . --ignore-src -y

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
             sudo depmod
             cd /usr/src/kvaser-drivers-*
             sudo sed -i 's/#define NR_VIRTUAL_DEV       1/#define NR_VIRTUAL_DEV       3/g' virtualcan/virtualcan.h
-            sudo make -C virtualcan
+            sudo make virtualcan
             sudo install -m 644 virtualcan/kvvirtualcan.ko /lib/modules/`uname -r`/updates/dkms/
             sudo virtualcan.sh start
       - run:
@@ -62,7 +62,7 @@ jobs:
             sudo depmod
             cd /usr/src/kvaser-drivers-*
             sudo sed -i 's/#define NR_VIRTUAL_DEV       1/#define NR_VIRTUAL_DEV       3/g' virtualcan/virtualcan.h
-            sudo make -C virtualcan
+            sudo make virtualcan
             sudo install -m 644 virtualcan/kvvirtualcan.ko /lib/modules/`uname -r`/updates/dkms/
             sudo virtualcan.sh start
       - run:

--- a/tests/reader_writer_1000hz.test
+++ b/tests/reader_writer_1000hz.test
@@ -19,7 +19,7 @@
 
   <test test-name="bridge_1000hz_pub" pkg="rostest" type="hztest" time-limit="10.0">
     <param name="hz" value="1000.0" />
-    <param name="hzerror" value="15.0" />
+    <param name="hzerror" value="20.0" />
     <param name="test_duration" value="3.0" />
     <param name="topic" value="/reader2/can_tx" />
   </test>


### PR DESCRIPTION
- Starts using the Circle CI Ubuntu 16.04 image to closer match our typical deployments.
- Starts using the new [`kvaser-linux` PPA](https://launchpad.net/~jwhitleyastuff/+archive/ubuntu/kvaser-linux) which splits up `canlib`, `linlib`, and `kvaser-drivers` for different use cases. This speeds up the build time from ~5:00 minutes to <=3:00 minutes.
- Sets the 1000Hz test to have a +-20Hz window since some tests were failing on the CI servers with 15.