### PR TITLE
Default launch file to output to screen.

### DIFF
--- a/launch/kvaser_can_bridge.launch
+++ b/launch/kvaser_can_bridge.launch
@@ -4,7 +4,7 @@
   <arg name="can_circuit_id" default="0" />
   <arg name="can_bit_rate" default="500000" />
 
-  <node pkg="kvaser_interface" type="kvaser_can_bridge" name="kvaser_can_bridge">
+  <node pkg="kvaser_interface" type="kvaser_can_bridge" name="kvaser_can_bridge" output="screen">
     <param name="can_hardware_id" value="$(arg can_hardware_id)" />
     <param name="can_circuit_id" value="$(arg can_circuit_id)" />
     <param name="can_bit_rate" value="$(arg can_bit_rate)" />


### PR DESCRIPTION
This change would default the `kvaser_interface.launch` file to have the `kvaser_interface` node output it's data to the screen, rather than hiding it when used in other launch files. This is very useful for troubleshooting and general use to make sure that the correct hardware ID, circuit ID, and bitrate were accepted by the driver on launch.