### PR TITLE
Fix/slow response

### DIFF
--- a/src/kvaser_interface.cpp
+++ b/src/kvaser_interface.cpp
@@ -147,7 +147,6 @@ ReturnStatuses KvaserCan::read(CanMsg *msg)
   {
     return ReturnStatuses::CHANNEL_CLOSED;
   }
-  auto start = std::chrono::steady_clock::now();
 
   // Make sure the incoming message is empty
   msg->id = 0;
@@ -175,10 +174,6 @@ ReturnStatuses KvaserCan::read(CanMsg *msg)
   }
 
   KvaserCanUtils::setMsgFromFlags(msg, flags);
-
-  auto end = std::chrono::steady_clock::now();
-  auto diff = end - start;
-  std::cout << "read(): " << diff.count() << std::endl;
 
   switch (ret)
   {

--- a/src/kvaser_interface.cpp
+++ b/src/kvaser_interface.cpp
@@ -158,12 +158,11 @@ ReturnStatuses KvaserCan::read(CanMsg *msg)
   int64_t id_proxy = 0;
   uint32_t flags = 0;
   char data[64];
-  size_t bytes = 0;
 
   canStatus ret = canRead(*handle, &id_proxy, data, &msg->dlc, &flags, &msg->timestamp);
 
   msg->id = static_cast<uint32_t>(id_proxy);
-  bytes = KvaserCanUtils::dlcToSize(msg->dlc);
+  size_t bytes = KvaserCanUtils::dlcToSize(msg->dlc);
 
   msg->data.reserve(bytes);
 

--- a/src/kvaser_interface.cpp
+++ b/src/kvaser_interface.cpp
@@ -162,13 +162,18 @@ ReturnStatuses KvaserCan::read(CanMsg *msg)
   canStatus ret = canRead(*handle, &id_proxy, data, &msg->dlc, &flags, &msg->timestamp);
 
   msg->id = static_cast<uint32_t>(id_proxy);
-  size_t bytes = KvaserCanUtils::dlcToSize(msg->dlc);
 
-  msg->data.reserve(bytes);
-
-  for (uint8_t i = 0; i < bytes; ++i)
+  // Only process payload if dlc != 0
+  if (msg->dlc != 0)
   {
-    msg->data.emplace_back(std::move(data[i]));
+    size_t bytes = KvaserCanUtils::dlcToSize(msg->dlc);
+
+    msg->data.reserve(bytes);
+
+    for (uint8_t i = 0; i < bytes; ++i)
+    {
+      msg->data.emplace_back(std::move(data[i]));
+    }
   }
 
   KvaserCanUtils::setMsgFromFlags(msg, flags);

--- a/src/kvaser_interface.cpp
+++ b/src/kvaser_interface.cpp
@@ -13,7 +13,6 @@
 #include <sstream>
 #include <algorithm>
 #include <iomanip>
-#include <chrono>
 
 using namespace AS::CAN;
 

--- a/src/kvaser_interface.cpp
+++ b/src/kvaser_interface.cpp
@@ -13,6 +13,7 @@
 #include <sstream>
 #include <algorithm>
 #include <iomanip>
+#include <chrono>
 
 using namespace AS::CAN;
 
@@ -67,6 +68,7 @@ ReturnStatuses KvaserCan::open(const uint32_t &channel_index,
 {
   if (!on_bus)
   {
+    auto start = std::chrono::steady_clock::now();
     int32_t numChan = -1;
     KvaserCanUtils::getChannelCount(&numChan);
 
@@ -110,6 +112,8 @@ ReturnStatuses KvaserCan::open(const uint32_t &channel_index,
       return ReturnStatuses::INIT_FAILED;
 
     on_bus = true;
+    auto end = std::chrono::steady_clock::now();
+    std::cout << "open(): " << (end - start).count() << std::endl;
   }
 
   return ReturnStatuses::OK;
@@ -123,6 +127,7 @@ bool KvaserCan::isOpen()
   }
   else
   {
+    auto start = std::chrono::steady_clock::now();
     if (on_bus)
     {
       uint64_t flags;
@@ -146,6 +151,8 @@ bool KvaserCan::isOpen()
     {
       return false;
     }
+    auto end = std::chrono::steady_clock::now();
+    std::cout << "isOpen(): " << (end - start).count() << std::endl;
   }
 }
 
@@ -170,6 +177,7 @@ ReturnStatuses KvaserCan::read(CanMsg *msg)
   {
     return ReturnStatuses::CHANNEL_CLOSED;
   }
+  auto start = std::chrono::steady_clock::now();
 
   // Make sure the incoming message is empty
   msg->id = 0;
@@ -198,6 +206,8 @@ ReturnStatuses KvaserCan::read(CanMsg *msg)
 
   KvaserCanUtils::setMsgFromFlags(msg, flags);
 
+  auto end = std::chrono::steady_clock::now();
+  std::cout << "read(): " << (end - start).count() << std::endl;
   switch (ret)
   {
     case canOK:


### PR DESCRIPTION
The current release of `kvaser_interface` suffers from very slow performance on reading and writing. The majority of this performance degradation comes from checking the on-bus status through the `linuxcan` API on every read and write. This PR removes the code to check the on-bus status with `linuxcan` every time, replacing it with a local status variable which is modified when the on-bus state changes. This does not fix the performance problem 100% but is a major improvement (approximately 200% reduction in latency).