### PR TITLE
Automatic Formatting of Code

### DIFF
--- a/include/kvaser_interface/kvaser_interface.h
+++ b/include/kvaser_interface/kvaser_interface.h
@@ -1,15 +1,14 @@
 /*
-* Unpublished Copyright (c) 2009-2019 AutonomouStuff, LLC, All Rights Reserved.
-*
-* This file is part of the Kvaser ROS driver which is released under the MIT license.
-* See file LICENSE included with this software or go to https://opensource.org/licenses/MIT for full license details.
-*/
+ * Unpublished Copyright (c) 2009-2019 AutonomouStuff, LLC, All Rights Reserved.
+ *
+ * This file is part of the Kvaser ROS driver which is released under the MIT license.
+ * See file LICENSE included with this software or go to https://opensource.org/licenses/MIT for full license details.
+ */
 
 #ifndef KVASER_INTERFACE_KVASER_INTERFACE_H
 #define KVASER_INTERFACE_KVASER_INTERFACE_H
 
-extern "C"
-{
+extern "C" {
 #include <canlib.h>
 }
 
@@ -24,7 +23,6 @@ namespace AS
 {
 namespace CAN
 {
-
 enum class ReturnStatuses
 {
   OK = 0,
@@ -79,251 +77,223 @@ enum class HardwareType
 
 class MsgFlags
 {
-  public:
-    friend bool operator==(const MsgFlags& lhs, const MsgFlags& rhs);
+public:
+  friend bool operator==(const MsgFlags& lhs, const MsgFlags& rhs);
 
-    void clear()
-    {
-      rtr = false;
-      std_id = false;
-      ext_id = false;
-      wakeup_mode = false;
-      nerr_active = false;
-      error_frame = false;
-      tx_ack = false;
-      tx_rq = false;
-      msg_delayed = false;
-      single_shot = false;
-      tx_nack = false;
-      arb_lost = false;
-      fd_msg = false;
-      fd_bitrate_switch = false;
-      fd_sndr_err_pass_md = false;
-    }
+  void clear()
+  {
+    rtr = false;
+    std_id = false;
+    ext_id = false;
+    wakeup_mode = false;
+    nerr_active = false;
+    error_frame = false;
+    tx_ack = false;
+    tx_rq = false;
+    msg_delayed = false;
+    single_shot = false;
+    tx_nack = false;
+    arb_lost = false;
+    fd_msg = false;
+    fd_bitrate_switch = false;
+    fd_sndr_err_pass_md = false;
+  }
 
-    bool rtr = false;
-    bool std_id = false;
-    bool ext_id = false;
-    bool wakeup_mode = false;
-    bool nerr_active = false;
-    bool error_frame = false;
-    bool tx_ack = false;
-    bool tx_rq = false;
-    bool msg_delayed = false;
-    bool single_shot = false;
-    bool tx_nack = false;
-    bool arb_lost = false;
-    bool fd_msg = false;
-    bool fd_bitrate_switch = false;
-    bool fd_sndr_err_pass_md = false;
+  bool rtr = false;
+  bool std_id = false;
+  bool ext_id = false;
+  bool wakeup_mode = false;
+  bool nerr_active = false;
+  bool error_frame = false;
+  bool tx_ack = false;
+  bool tx_rq = false;
+  bool msg_delayed = false;
+  bool single_shot = false;
+  bool tx_nack = false;
+  bool arb_lost = false;
+  bool fd_msg = false;
+  bool fd_bitrate_switch = false;
+  bool fd_sndr_err_pass_md = false;
 };
 
 bool operator==(const MsgFlags& lhs, const MsgFlags& rhs)
 {
-  return (lhs.rtr == rhs.rtr &&
-    lhs.std_id == rhs.std_id &&
-    lhs.ext_id == rhs.ext_id &&
-    lhs.wakeup_mode == rhs.wakeup_mode &&
-    lhs.nerr_active == rhs.nerr_active &&
-    lhs.error_frame == rhs.error_frame &&
-    lhs.tx_ack == rhs.tx_ack &&
-    lhs.tx_rq == rhs.tx_rq &&
-    lhs.msg_delayed == rhs.msg_delayed &&
-    lhs.single_shot == rhs.single_shot &&
-    lhs.tx_nack == rhs.tx_nack &&
-    lhs.arb_lost == rhs.arb_lost &&
-    lhs.fd_msg == rhs.fd_msg &&
-    lhs.fd_bitrate_switch == rhs.fd_bitrate_switch &&
-    lhs.fd_sndr_err_pass_md == rhs.fd_sndr_err_pass_md);
+  return (lhs.rtr == rhs.rtr && lhs.std_id == rhs.std_id && lhs.ext_id == rhs.ext_id &&
+          lhs.wakeup_mode == rhs.wakeup_mode && lhs.nerr_active == rhs.nerr_active &&
+          lhs.error_frame == rhs.error_frame && lhs.tx_ack == rhs.tx_ack && lhs.tx_rq == rhs.tx_rq &&
+          lhs.msg_delayed == rhs.msg_delayed && lhs.single_shot == rhs.single_shot && lhs.tx_nack == rhs.tx_nack &&
+          lhs.arb_lost == rhs.arb_lost && lhs.fd_msg == rhs.fd_msg && lhs.fd_bitrate_switch == rhs.fd_bitrate_switch &&
+          lhs.fd_sndr_err_pass_md == rhs.fd_sndr_err_pass_md);
 }
 
 class MsgErrFlags
 {
-  public:
-    friend bool operator==(const MsgErrFlags& lhs, const MsgErrFlags& rhs);
+public:
+  friend bool operator==(const MsgErrFlags& lhs, const MsgErrFlags& rhs);
 
-    void clear()
-    {
-      has_err = false;
-      hw_overrun_err = false;
-      sw_overrun_err = false;
-      stuff_err = false;
-      form_err = false;
-      crc_err = false;
-      bit0_err = false;
-      bit1_err = false;
-      any_overrun_err = false;
-      any_bit_err = false;
-      any_rx_err = false;
-    }
+  void clear()
+  {
+    has_err = false;
+    hw_overrun_err = false;
+    sw_overrun_err = false;
+    stuff_err = false;
+    form_err = false;
+    crc_err = false;
+    bit0_err = false;
+    bit1_err = false;
+    any_overrun_err = false;
+    any_bit_err = false;
+    any_rx_err = false;
+  }
 
-    bool has_err = false;
-    bool hw_overrun_err = false;
-    bool sw_overrun_err = false;
-    bool stuff_err = false;
-    bool form_err = false;
-    bool crc_err = false;
-    bool bit0_err = false;
-    bool bit1_err = false;
-    bool any_overrun_err = false;
-    bool any_bit_err = false;
-    bool any_rx_err = false;
+  bool has_err = false;
+  bool hw_overrun_err = false;
+  bool sw_overrun_err = false;
+  bool stuff_err = false;
+  bool form_err = false;
+  bool crc_err = false;
+  bool bit0_err = false;
+  bool bit1_err = false;
+  bool any_overrun_err = false;
+  bool any_bit_err = false;
+  bool any_rx_err = false;
 };
 
 bool operator==(const MsgErrFlags& lhs, const MsgErrFlags& rhs)
 {
-  return (lhs.has_err == rhs.has_err &&
-    lhs.hw_overrun_err == rhs.hw_overrun_err &&
-    lhs.sw_overrun_err == rhs.sw_overrun_err &&
-    lhs.stuff_err == rhs.stuff_err &&
-    lhs.form_err == rhs.form_err &&
-    lhs.crc_err == rhs.crc_err &&
-    lhs.bit0_err == rhs.bit0_err &&
-    lhs.bit1_err == rhs.bit1_err &&
-    lhs.any_overrun_err == rhs.any_overrun_err &&
-    lhs.any_bit_err == rhs.any_bit_err &&
-    lhs.any_rx_err == rhs.any_rx_err);
+  return (lhs.has_err == rhs.has_err && lhs.hw_overrun_err == rhs.hw_overrun_err &&
+          lhs.sw_overrun_err == rhs.sw_overrun_err && lhs.stuff_err == rhs.stuff_err && lhs.form_err == rhs.form_err &&
+          lhs.crc_err == rhs.crc_err && lhs.bit0_err == rhs.bit0_err && lhs.bit1_err == rhs.bit1_err &&
+          lhs.any_overrun_err == rhs.any_overrun_err && lhs.any_bit_err == rhs.any_bit_err &&
+          lhs.any_rx_err == rhs.any_rx_err);
 }
 
 class CanMsg
 {
-  public:
-    inline bool operator==(const CanMsg& other)
-    {
-      return (id == other.id &&
-        dlc == other.dlc &&
-        flags == other.flags &&
-        error_flags == other.error_flags &&
-        data == other.data &&
-        timestamp == other.timestamp);
-    }
+public:
+  inline bool operator==(const CanMsg& other)
+  {
+    return (id == other.id && dlc == other.dlc && flags == other.flags && error_flags == other.error_flags &&
+            data == other.data && timestamp == other.timestamp);
+  }
 
-    uint32_t id = 0;
-    uint32_t dlc = 0;
-    MsgFlags flags;
-    MsgErrFlags error_flags;
-    std::vector<uint8_t> data;
-    uint64_t timestamp = 0;
+  uint32_t id = 0;
+  uint32_t dlc = 0;
+  MsgFlags flags;
+  MsgErrFlags error_flags;
+  std::vector<uint8_t> data;
+  uint64_t timestamp = 0;
 };
 
 bool operator==(const CanMsg& lhs, const CanMsg& rhs)
 {
-  return (lhs.id == rhs.id &&
-    lhs.dlc == rhs.dlc &&
-    lhs.flags == rhs.flags &&
-    lhs.error_flags == rhs.error_flags &&
-    lhs.data == rhs.data &&
-    lhs.timestamp == rhs.timestamp);
+  return (lhs.id == rhs.id && lhs.dlc == rhs.dlc && lhs.flags == rhs.flags && lhs.error_flags == rhs.error_flags &&
+          lhs.data == rhs.data && lhs.timestamp == rhs.timestamp);
 }
 
 class KvaserCard
 {
-  public:
-    uint64_t serial_no = 0;
-    uint16_t firmware_rev_maj = 0;
-    uint16_t firmware_rev_min = 0;
-    uint16_t firmware_rev_rel = 0;
-    uint16_t firmware_rev_bld = 0;
-    HardwareType hw_type = HardwareType::NONE;
-    std::string dev_name;
-    std::string upc_no;
-    std::string driver_name;
-    uint16_t driver_ver_maj = 0;
-    uint16_t driver_ver_min = 0;
-    uint16_t driver_ver_bld = 0;
-    bool all_data_valid = true;
+public:
+  uint64_t serial_no = 0;
+  uint16_t firmware_rev_maj = 0;
+  uint16_t firmware_rev_min = 0;
+  uint16_t firmware_rev_rel = 0;
+  uint16_t firmware_rev_bld = 0;
+  HardwareType hw_type = HardwareType::NONE;
+  std::string dev_name;
+  std::string upc_no;
+  std::string driver_name;
+  uint16_t driver_ver_maj = 0;
+  uint16_t driver_ver_min = 0;
+  uint16_t driver_ver_bld = 0;
+  bool all_data_valid = true;
 };
 
-class KvaserChannel
-: public KvaserCard
+class KvaserChannel : public KvaserCard
 {
-  public:
-    KvaserChannel()
-    : KvaserCard()
-    {}
+public:
+  KvaserChannel() : KvaserCard()
+  {
+  }
 
-    uint32_t channel_idx = 0;
-    uint32_t channel_no_on_card = 0;
-    uint32_t max_bitrate = 0;
+  uint32_t channel_idx = 0;
+  uint32_t channel_no_on_card = 0;
+  uint32_t max_bitrate = 0;
 };
 
 class KvaserCan
 {
-  public:
-    KvaserCan();
+public:
+  KvaserCan();
 
-    // Moving and copying not allowed because of
-    // state associated with handle.
-    KvaserCan(KvaserCan && p) = delete;
-    KvaserCan &operator=(KvaserCan && p) = delete;
-    KvaserCan(const KvaserCan &) = delete;
-    KvaserCan &operator=(const KvaserCan &) = delete;
+  // Moving and copying not allowed because of
+  // state associated with handle.
+  KvaserCan(KvaserCan&& p) = delete;
+  KvaserCan& operator=(KvaserCan&& p) = delete;
+  KvaserCan(const KvaserCan&) = delete;
+  KvaserCan& operator=(const KvaserCan&) = delete;
 
-    ~KvaserCan();
+  ~KvaserCan();
 
-    // Called to pass in parameters and open can link
-    ReturnStatuses open(const uint64_t &hardware_id,
-                        const uint32_t &circuit_id,
-                        const uint32_t &bitrate,
-                        const bool &echo_on = true);
+  // Called to pass in parameters and open can link
+  ReturnStatuses open(const uint64_t& hardware_id, const uint32_t& circuit_id, const uint32_t& bitrate,
+                      const bool& echo_on = true);
 
-    ReturnStatuses open(const uint32_t &channel_index,
-                        const uint32_t &bitrate,
-                        const bool &echo_on = true);
+  ReturnStatuses open(const uint32_t& channel_index, const uint32_t& bitrate, const bool& echo_on = true);
 
-    // Close the can link
-    ReturnStatuses close();
+  // Close the can link
+  ReturnStatuses close();
 
-    // Check to see if the CAN link is open
-    bool isOpen();
+  // Check to see if the CAN link is open
+  bool isOpen();
 
-    // Read a message
-    ReturnStatuses read(CanMsg *msg);
-    ReturnStatuses registerReadCallback(std::function<void(void)> callable);
+  // Read a message
+  ReturnStatuses read(CanMsg* msg);
+  ReturnStatuses registerReadCallback(std::function<void(void)> callable);
 
-    // Send a message
-    ReturnStatuses write(CanMsg &&msg);
+  // Send a message
+  ReturnStatuses write(CanMsg&& msg);
 
-    // Read callback function
-    std::function<void(void)> readFunc;
+  // Read callback function
+  std::function<void(void)> readFunc;
 
-  private:
-    std::shared_ptr<CanHandle> handle;
-    bool on_bus;
+private:
+  std::shared_ptr<CanHandle> handle;
+  bool on_bus;
 };
 
 class KvaserReadCbProxy
 {
-  public:
-    static ReturnStatuses registerCb(KvaserCan *canObj, const std::shared_ptr<CanHandle> &hdl);
+public:
+  static ReturnStatuses registerCb(KvaserCan* canObj, const std::shared_ptr<CanHandle>& hdl);
 
-  private:
-    static void proxyCallback(canNotifyData *data);
+private:
+  static void proxyCallback(canNotifyData* data);
 
-    static KvaserCan *kvCanObj;
-    static std::shared_ptr<CanHandle> handle;
+  static KvaserCan* kvCanObj;
+  static std::shared_ptr<CanHandle> handle;
 };
 
 class KvaserCanUtils
 {
-  public:
-    // In classic CAN, the DLC == payload size. For CAN FD, the DLC
-    // indicates the payload size but the two values aren't the same.
-    // These two functions allow for translating between the DLC and
-    // the payload size. See
-    // https://www.kvaser.com/wp-content/uploads/2016/10/comparing-can-fd-with-classical-can.pdf
-    // for more information.
-    static size_t dlcToSize(const uint8_t &dlc);
-    static uint8_t sizeToDlc(const size_t &size);
+public:
+  // In classic CAN, the DLC == payload size. For CAN FD, the DLC
+  // indicates the payload size but the two values aren't the same.
+  // These two functions allow for translating between the DLC and
+  // the payload size. See
+  // https://www.kvaser.com/wp-content/uploads/2016/10/comparing-can-fd-with-classical-can.pdf
+  // for more information.
+  static size_t dlcToSize(const uint8_t& dlc);
+  static uint8_t sizeToDlc(const size_t& size);
 
-    static ReturnStatuses canlibStatToReturnStatus(const int32_t &canlibStat);
-    static void getChannelCount(int32_t *numChannels);
-    static std::vector<std::shared_ptr<KvaserCard>> getCards();
-    static std::vector<std::shared_ptr<KvaserChannel>> getChannels();
-    static std::vector<std::shared_ptr<KvaserChannel>> getChannelsOnCard(const uint64_t &serialNo);
-    static std::string returnStatusDesc(const ReturnStatuses &ret);
-    static void setMsgFromFlags(CanMsg *msg, const uint32_t &flags);
-    static void setFlagsFromMsg(const CanMsg &msg, uint32_t *flags);
+  static ReturnStatuses canlibStatToReturnStatus(const int32_t& canlibStat);
+  static void getChannelCount(int32_t* numChannels);
+  static std::vector<std::shared_ptr<KvaserCard>> getCards();
+  static std::vector<std::shared_ptr<KvaserChannel>> getChannels();
+  static std::vector<std::shared_ptr<KvaserChannel>> getChannelsOnCard(const uint64_t& serialNo);
+  static std::string returnStatusDesc(const ReturnStatuses& ret);
+  static void setMsgFromFlags(CanMsg* msg, const uint32_t& flags);
+  static void setFlagsFromMsg(const CanMsg& msg, uint32_t* flags);
 };
 
 }  // namespace CAN

--- a/include/kvaser_interface/kvaser_interface.h
+++ b/include/kvaser_interface/kvaser_interface.h
@@ -8,9 +8,12 @@
 #ifndef KVASER_INTERFACE_KVASER_INTERFACE_H
 #define KVASER_INTERFACE_KVASER_INTERFACE_H
 
-extern "C" {
+// clang-format off
+extern "C"
+{
 #include <canlib.h>
 }
+// clang-format on
 
 // C++ Includes
 #include <iostream>

--- a/src/kvaser_can_bridge.cpp
+++ b/src/kvaser_can_bridge.cpp
@@ -1,9 +1,9 @@
 /*
-* Unpublished Copyright (c) 2009-2019 AutonomouStuff, LLC, All Rights Reserved.
-*
-* This file is part of the Kvaser ROS driver which is released under the MIT license.
-* See file LICENSE included with this software or go to https://opensource.org/licenses/MIT for full license details.
-*/
+ * Unpublished Copyright (c) 2009-2019 AutonomouStuff, LLC, All Rights Reserved.
+ *
+ * This file is part of the Kvaser ROS driver which is released under the MIT license.
+ * See file LICENSE included with this software or go to https://opensource.org/licenses/MIT for full license details.
+ */
 
 #include <thread>
 #include <mutex>
@@ -34,8 +34,8 @@ void can_read()
 
       if (ret != ReturnStatuses::OK)
       {
-        ROS_ERROR_THROTTLE(0.5, "Kvaser CAN Interface - Error opening reader: %d - %s",
-          static_cast<int>(ret), KvaserCanUtils::returnStatusDesc(ret).c_str());
+        ROS_ERROR_THROTTLE(0.5, "Kvaser CAN Interface - Error opening reader: %d - %s", static_cast<int>(ret),
+                           KvaserCanUtils::returnStatusDesc(ret).c_str());
         break;
       }
     }
@@ -46,18 +46,14 @@ void can_read()
 
       ret = can_reader.read(&msg);
 
-      if (ret  == ReturnStatuses::OK)
+      if (ret == ReturnStatuses::OK)
       {
         // Only publish if msg is not CAN FD,
         // a wakeup message, a transmit acknowledgement,
         // a transmit request, a delay notification,
         // or a failed single-shot.
-        if (!(msg.flags.fd_msg ||
-              msg.flags.wakeup_mode ||
-              msg.flags.tx_ack ||
-              msg.flags.tx_rq ||
-              msg.flags.msg_delayed ||
-              msg.flags.tx_nack))
+        if (!(msg.flags.fd_msg || msg.flags.wakeup_mode || msg.flags.tx_ack || msg.flags.tx_rq ||
+              msg.flags.msg_delayed || msg.flags.tx_nack))
         {
           can_msgs::Frame can_pub_msg;
           can_pub_msg.header.frame_id = "0";
@@ -74,8 +70,8 @@ void can_read()
       else
       {
         if (ret != ReturnStatuses::NO_MESSAGES_RECEIVED)
-          ROS_WARN_THROTTLE(0.5, "Kvaser CAN Interface - Error reading CAN message: %d - %s",
-            static_cast<int>(ret), KvaserCanUtils::returnStatusDesc(ret).c_str());
+          ROS_WARN_THROTTLE(0.5, "Kvaser CAN Interface - Error reading CAN message: %d - %s", static_cast<int>(ret),
+                            KvaserCanUtils::returnStatusDesc(ret).c_str());
 
         break;
       }
@@ -94,8 +90,8 @@ void can_rx_callback(const can_msgs::Frame::ConstPtr& ros_msg)
 
     if (ret != ReturnStatuses::OK)
     {
-      ROS_ERROR_THROTTLE(0.5, "Kvaser CAN Interface - Error opening writer: %d - %s",
-        static_cast<int>(ret), KvaserCanUtils::returnStatusDesc(ret).c_str());
+      ROS_ERROR_THROTTLE(0.5, "Kvaser CAN Interface - Error opening writer: %d - %s", static_cast<int>(ret),
+                         KvaserCanUtils::returnStatusDesc(ret).c_str());
     }
   }
 
@@ -119,8 +115,8 @@ void can_rx_callback(const can_msgs::Frame::ConstPtr& ros_msg)
 
     if (ret != ReturnStatuses::OK)
     {
-      ROS_WARN_THROTTLE(0.5, "Kvaser CAN Interface - CAN send error: %d - %s",
-        static_cast<int>(ret), KvaserCanUtils::returnStatusDesc(ret).c_str());
+      ROS_WARN_THROTTLE(0.5, "Kvaser CAN Interface - CAN send error: %d - %s", static_cast<int>(ret),
+                        KvaserCanUtils::returnStatusDesc(ret).c_str());
     }
   }
 }
@@ -197,16 +193,16 @@ int main(int argc, char** argv)
     }
     else
     {
-      ROS_ERROR("Kvaser CAN Interface - Error registering reader callback: %d - %s",
-        static_cast<int>(ret), KvaserCanUtils::returnStatusDesc(ret).c_str());
+      ROS_ERROR("Kvaser CAN Interface - Error registering reader callback: %d - %s", static_cast<int>(ret),
+                KvaserCanUtils::returnStatusDesc(ret).c_str());
       ros::shutdown();
       return -1;
     }
   }
   else
   {
-    ROS_ERROR("Kvaser CAN Interface - Error opening reader: %d - %s",
-      static_cast<int>(ret), KvaserCanUtils::returnStatusDesc(ret).c_str());
+    ROS_ERROR("Kvaser CAN Interface - Error opening reader: %d - %s", static_cast<int>(ret),
+              KvaserCanUtils::returnStatusDesc(ret).c_str());
     ros::shutdown();
     return -1;
   }
@@ -218,8 +214,8 @@ int main(int argc, char** argv)
     ret = can_reader.close();
 
     if (ret != ReturnStatuses::OK)
-      ROS_ERROR("Kvaser CAN Interface - Error closing reader: %d - %s",
-        static_cast<int>(ret), KvaserCanUtils::returnStatusDesc(ret).c_str());
+      ROS_ERROR("Kvaser CAN Interface - Error closing reader: %d - %s", static_cast<int>(ret),
+                KvaserCanUtils::returnStatusDesc(ret).c_str());
   }
 
   if (can_writer.isOpen())
@@ -227,8 +223,8 @@ int main(int argc, char** argv)
     ret = can_writer.close();
 
     if (ret != ReturnStatuses::OK)
-      ROS_ERROR("Kvaser CAN Interface - Error closing writer: %d - %s",
-        static_cast<int>(ret), KvaserCanUtils::returnStatusDesc(ret).c_str());
+      ROS_ERROR("Kvaser CAN Interface - Error closing writer: %d - %s", static_cast<int>(ret),
+                KvaserCanUtils::returnStatusDesc(ret).c_str());
   }
 
   return 0;

--- a/src/kvaser_interface.cpp
+++ b/src/kvaser_interface.cpp
@@ -1,9 +1,9 @@
 /*
-* Unpublished Copyright (c) 2009-2019 AutonomouStuff, LLC, All Rights Reserved.
-*
-* This file is part of the Kvaser ROS 1.0 driver which is released under the MIT license.
-* See file LICENSE included with this software or go to https://opensource.org/licenses/MIT for full license details.
-*/
+ * Unpublished Copyright (c) 2009-2019 AutonomouStuff, LLC, All Rights Reserved.
+ *
+ * This file is part of the Kvaser ROS 1.0 driver which is released under the MIT license.
+ * See file LICENSE included with this software or go to https://opensource.org/licenses/MIT for full license details.
+ */
 
 #include <kvaser_interface/kvaser_interface.h>
 
@@ -16,11 +16,10 @@
 
 using namespace AS::CAN;
 
-KvaserCan *KvaserReadCbProxy::kvCanObj = nullptr;
+KvaserCan* KvaserReadCbProxy::kvCanObj = nullptr;
 std::shared_ptr<CanHandle> KvaserReadCbProxy::handle = std::shared_ptr<CanHandle>(nullptr);
 
-KvaserCan::KvaserCan() :
-  handle(new CanHandle)
+KvaserCan::KvaserCan() : handle(new CanHandle)
 {
   *handle = -1;
   canInitializeLibrary();
@@ -32,10 +31,8 @@ KvaserCan::~KvaserCan()
     canClose(*handle);
 }
 
-ReturnStatuses KvaserCan::open(const uint64_t &hardware_id,
-                               const uint32_t &circuit_id,
-                               const uint32_t &bitrate,
-                               const bool &echo_on)
+ReturnStatuses KvaserCan::open(const uint64_t& hardware_id, const uint32_t& circuit_id, const uint32_t& bitrate,
+                               const bool& echo_on)
 {
   auto channels = KvaserCanUtils::getChannels();
   uint32_t channel_index = 0;
@@ -44,10 +41,9 @@ ReturnStatuses KvaserCan::open(const uint64_t &hardware_id,
   if (channels.size() < 1)
     return ReturnStatuses::NO_CHANNELS_FOUND;
 
-  for (const auto &channel : channels)
+  for (const auto& channel : channels)
   {
-    if (hardware_id == channel->serial_no &&
-        circuit_id == channel->channel_no_on_card)
+    if (hardware_id == channel->serial_no && circuit_id == channel->channel_no_on_card)
     {
       channel_index = channel->channel_idx;
       channel_found = true;
@@ -61,9 +57,7 @@ ReturnStatuses KvaserCan::open(const uint64_t &hardware_id,
     return ReturnStatuses::BAD_PARAM;
 }
 
-ReturnStatuses KvaserCan::open(const uint32_t &channel_index,
-                               const uint32_t &bitrate,
-                               const bool &echo_on)
+ReturnStatuses KvaserCan::open(const uint32_t& channel_index, const uint32_t& bitrate, const bool& echo_on)
 {
   if (!on_bus)
   {
@@ -84,11 +78,20 @@ ReturnStatuses KvaserCan::open(const uint32_t &channel_index,
 
     switch (bitrate)
     {
-      case 125000: freq = canBITRATE_125K; break;
-      case 250000: freq = canBITRATE_250K; break;
-      case 500000: freq = canBITRATE_500K; break;
-      case 1000000: freq = canBITRATE_1M; break;
-      default: return  ReturnStatuses::BAD_PARAM;
+      case 125000:
+        freq = canBITRATE_125K;
+        break;
+      case 250000:
+        freq = canBITRATE_250K;
+        break;
+      case 500000:
+        freq = canBITRATE_500K;
+        break;
+      case 1000000:
+        freq = canBITRATE_1M;
+        break;
+      default:
+        return ReturnStatuses::BAD_PARAM;
     }
 
     if (canSetBusParams(*handle, freq, 0, 0, 0, 0, 0) < 0)
@@ -140,7 +143,7 @@ ReturnStatuses KvaserCan::close()
     return ReturnStatuses::OK;
 }
 
-ReturnStatuses KvaserCan::read(CanMsg *msg)
+ReturnStatuses KvaserCan::read(CanMsg* msg)
 {
   if (*handle < 0)
   {
@@ -216,7 +219,7 @@ ReturnStatuses KvaserCan::registerReadCallback(std::function<void(void)> callabl
   }
 }
 
-ReturnStatuses KvaserCan::write(CanMsg &&msg)
+ReturnStatuses KvaserCan::write(CanMsg&& msg)
 {
   if (*handle < 0)
     return ReturnStatuses::CHANNEL_CLOSED;
@@ -235,7 +238,7 @@ ReturnStatuses KvaserCan::write(CanMsg &&msg)
   return (ret == canOK) ? ReturnStatuses::OK : ReturnStatuses::WRITE_FAILED;
 }
 
-ReturnStatuses KvaserReadCbProxy::registerCb(KvaserCan *canObj, const std::shared_ptr<CanHandle> &hdl)
+ReturnStatuses KvaserReadCbProxy::registerCb(KvaserCan* canObj, const std::shared_ptr<CanHandle>& hdl)
 {
   handle = std::shared_ptr<CanHandle>(hdl);
 
@@ -245,11 +248,7 @@ ReturnStatuses KvaserReadCbProxy::registerCb(KvaserCan *canObj, const std::share
   {
     kvCanObj = canObj;
 
-    auto stat = canSetNotify(
-      *(hdl),
-      &KvaserReadCbProxy::proxyCallback,
-      canNOTIFY_RX,
-      reinterpret_cast<char*>(0));
+    auto stat = canSetNotify(*(hdl), &KvaserReadCbProxy::proxyCallback, canNOTIFY_RX, reinterpret_cast<char*>(0));
 
     if (stat == canOK)
     {
@@ -263,12 +262,12 @@ ReturnStatuses KvaserReadCbProxy::registerCb(KvaserCan *canObj, const std::share
   }
 }
 
-void KvaserReadCbProxy::proxyCallback(canNotifyData *data)
+void KvaserReadCbProxy::proxyCallback(canNotifyData* data)
 {
   kvCanObj->readFunc();
 }
 
-ReturnStatuses KvaserCanUtils::canlibStatToReturnStatus(const int32_t &canlibStat)
+ReturnStatuses KvaserCanUtils::canlibStatToReturnStatus(const int32_t& canlibStat)
 {
   switch (canlibStat)
   {
@@ -283,7 +282,7 @@ ReturnStatuses KvaserCanUtils::canlibStatToReturnStatus(const int32_t &canlibSta
   }
 }
 
-size_t KvaserCanUtils::dlcToSize(const uint8_t &dlc)
+size_t KvaserCanUtils::dlcToSize(const uint8_t& dlc)
 {
   if (dlc < 9)
   {
@@ -320,7 +319,7 @@ size_t KvaserCanUtils::dlcToSize(const uint8_t &dlc)
   }
 }
 
-uint8_t KvaserCanUtils::sizeToDlc(const size_t &size)
+uint8_t KvaserCanUtils::sizeToDlc(const size_t& size)
 {
   if (size < 9)
   {
@@ -357,7 +356,7 @@ uint8_t KvaserCanUtils::sizeToDlc(const size_t &size)
   }
 }
 
-void KvaserCanUtils::getChannelCount(int32_t *numChan)
+void KvaserCanUtils::getChannelCount(int32_t* numChan)
 {
   auto stat = canGetNumberOfChannels(numChan);
 
@@ -371,11 +370,11 @@ std::vector<std::shared_ptr<KvaserCard>> KvaserCanUtils::getCards()
 
   std::vector<std::shared_ptr<KvaserCard>> cards;
 
-  for (const auto &channel : channels)
+  for (const auto& channel : channels)
   {
     bool found = false;
 
-    for (const auto &card : cards)
+    for (const auto& card : cards)
     {
       if (card->serial_no == channel->serial_no)
         found = true;
@@ -509,13 +508,13 @@ std::vector<std::shared_ptr<KvaserChannel>> KvaserCanUtils::getChannels()
   return channels;
 }
 
-std::vector<std::shared_ptr<KvaserChannel>> KvaserCanUtils::getChannelsOnCard(const uint64_t &serialNo)
+std::vector<std::shared_ptr<KvaserChannel>> KvaserCanUtils::getChannelsOnCard(const uint64_t& serialNo)
 {
   std::vector<std::shared_ptr<KvaserChannel>> channelsOnCard;
 
   auto channels = getChannels();
 
-  for (const auto &channel : channels)
+  for (const auto& channel : channels)
   {
     if (channel->serial_no == serialNo)
       channelsOnCard.emplace_back(std::move(channel));
@@ -548,7 +547,7 @@ std::string KvaserCanUtils::returnStatusDesc(const ReturnStatuses& ret)
   return status_string;
 }
 
-void KvaserCanUtils::setMsgFromFlags(CanMsg *msg, const uint32_t &flags)
+void KvaserCanUtils::setMsgFromFlags(CanMsg* msg, const uint32_t& flags)
 {
   // Regular CAN message flags
   msg->flags.rtr = ((flags & canMSG_RTR) > 0);
@@ -583,33 +582,33 @@ void KvaserCanUtils::setMsgFromFlags(CanMsg *msg, const uint32_t &flags)
   msg->error_flags.any_rx_err = ((flags & canMSGERR_BUSERR) > 0);
 }
 
-void KvaserCanUtils::setFlagsFromMsg(const CanMsg &msg, uint32_t *flags)
+void KvaserCanUtils::setFlagsFromMsg(const CanMsg& msg, uint32_t* flags)
 {
   // Regular CAN message flags
-  msg.flags.rtr ? *flags |= canMSG_RTR : *flags &= ~canMSG_RTR;
-  msg.flags.std_id ? *flags |= canMSG_STD : *flags &= ~canMSG_STD;
-  msg.flags.ext_id ? *flags |= canMSG_EXT : *flags &= ~canMSG_EXT;
-  msg.flags.wakeup_mode ? *flags |= canMSG_WAKEUP : *flags &= ~canMSG_WAKEUP;
-  msg.flags.nerr_active ? *flags |= canMSG_NERR : *flags &= ~canMSG_NERR;
-  msg.flags.error_frame ? *flags |= canMSG_ERROR_FRAME : *flags &= ~canMSG_ERROR_FRAME;
-  msg.flags.tx_ack ? *flags |= canMSG_TXACK : *flags &= ~canMSG_TXACK;
-  msg.flags.tx_rq ? *flags |= canMSG_TXRQ : *flags &= ~canMSG_TXRQ;
-  msg.flags.msg_delayed ? *flags |= canMSG_DELAY_MSG : *flags &= ~canMSG_DELAY_MSG;
-  msg.flags.single_shot ? *flags |= canMSG_SINGLE_SHOT : *flags &= ~canMSG_SINGLE_SHOT;
-  msg.flags.tx_nack ? *flags |= canMSG_TXNACK : *flags &= ~canMSG_TXNACK;
-  msg.flags.arb_lost ? *flags |= canMSG_ABL : *flags &= ~canMSG_ABL;
+  msg.flags.rtr ? * flags |= canMSG_RTR : * flags &= ~canMSG_RTR;
+  msg.flags.std_id ? * flags |= canMSG_STD : * flags &= ~canMSG_STD;
+  msg.flags.ext_id ? * flags |= canMSG_EXT : * flags &= ~canMSG_EXT;
+  msg.flags.wakeup_mode ? * flags |= canMSG_WAKEUP : * flags &= ~canMSG_WAKEUP;
+  msg.flags.nerr_active ? * flags |= canMSG_NERR : * flags &= ~canMSG_NERR;
+  msg.flags.error_frame ? * flags |= canMSG_ERROR_FRAME : * flags &= ~canMSG_ERROR_FRAME;
+  msg.flags.tx_ack ? * flags |= canMSG_TXACK : * flags &= ~canMSG_TXACK;
+  msg.flags.tx_rq ? * flags |= canMSG_TXRQ : * flags &= ~canMSG_TXRQ;
+  msg.flags.msg_delayed ? * flags |= canMSG_DELAY_MSG : * flags &= ~canMSG_DELAY_MSG;
+  msg.flags.single_shot ? * flags |= canMSG_SINGLE_SHOT : * flags &= ~canMSG_SINGLE_SHOT;
+  msg.flags.tx_nack ? * flags |= canMSG_TXNACK : * flags &= ~canMSG_TXNACK;
+  msg.flags.arb_lost ? * flags |= canMSG_ABL : * flags &= ~canMSG_ABL;
 
   // CAN FD *flags
-  msg.flags.fd_msg ? *flags |= canFDMSG_FDF : *flags &= ~canFDMSG_FDF;
-  msg.flags.fd_bitrate_switch ? *flags |= canFDMSG_BRS : *flags &= ~canFDMSG_BRS;
-  msg.flags.fd_sndr_err_pass_md ? *flags |= canFDMSG_ESI : *flags &= ~canFDMSG_ESI;
+  msg.flags.fd_msg ? * flags |= canFDMSG_FDF : * flags &= ~canFDMSG_FDF;
+  msg.flags.fd_bitrate_switch ? * flags |= canFDMSG_BRS : * flags &= ~canFDMSG_BRS;
+  msg.flags.fd_sndr_err_pass_md ? * flags |= canFDMSG_ESI : * flags &= ~canFDMSG_ESI;
 
   // Error *flags
-  msg.error_flags.hw_overrun_err ? *flags |= canMSGERR_HW_OVERRUN : *flags &= ~canMSGERR_HW_OVERRUN;
-  msg.error_flags.sw_overrun_err ? *flags |= canMSGERR_SW_OVERRUN : *flags &= ~canMSGERR_SW_OVERRUN;
-  msg.error_flags.stuff_err ? *flags |= canMSGERR_STUFF : *flags &= ~canMSGERR_STUFF;
-  msg.error_flags.form_err ? *flags |= canMSGERR_FORM : *flags &= ~canMSGERR_FORM;
-  msg.error_flags.crc_err ? *flags |= canMSGERR_CRC : *flags &= ~canMSGERR_CRC;
-  msg.error_flags.bit0_err ? *flags |= canMSGERR_BIT0 : *flags &= ~canMSGERR_BIT0;
-  msg.error_flags.bit1_err ? *flags |= canMSGERR_BIT1 : *flags &= ~canMSGERR_BIT1;
+  msg.error_flags.hw_overrun_err ? * flags |= canMSGERR_HW_OVERRUN : * flags &= ~canMSGERR_HW_OVERRUN;
+  msg.error_flags.sw_overrun_err ? * flags |= canMSGERR_SW_OVERRUN : * flags &= ~canMSGERR_SW_OVERRUN;
+  msg.error_flags.stuff_err ? * flags |= canMSGERR_STUFF : * flags &= ~canMSGERR_STUFF;
+  msg.error_flags.form_err ? * flags |= canMSGERR_FORM : * flags &= ~canMSGERR_FORM;
+  msg.error_flags.crc_err ? * flags |= canMSGERR_CRC : * flags &= ~canMSGERR_CRC;
+  msg.error_flags.bit0_err ? * flags |= canMSGERR_BIT0 : * flags &= ~canMSGERR_BIT0;
+  msg.error_flags.bit1_err ? * flags |= canMSGERR_BIT1 : * flags &= ~canMSGERR_BIT1;
 }

--- a/tests/kvaser_interface_ros_tests.cpp
+++ b/tests/kvaser_interface_ros_tests.cpp
@@ -1,9 +1,9 @@
 /*
-* Unpublished Copyright (c) 2009-2019 AutonomouStuff, LLC, All Rights Reserved.
-*
-* This file is part of the Kvaser ROS driver which is released under the MIT license.
-* See file LICENSE included with this software or go to https://opensource.org/licenses/MIT for full license details.
-*/
+ * Unpublished Copyright (c) 2009-2019 AutonomouStuff, LLC, All Rights Reserved.
+ *
+ * This file is part of the Kvaser ROS driver which is released under the MIT license.
+ * See file LICENSE included with this software or go to https://opensource.org/licenses/MIT for full license details.
+ */
 
 #include <ros/ros.h>
 #include <kvaser_interface/kvaser_interface.h>
@@ -94,8 +94,7 @@ int main(int argc, char** argv)
   // Wait until reader and writer are ready
   while (true)
   {
-    if (msg_pub.getNumSubscribers() < 1 &&
-        msg_sub.getNumPublishers() < 1)
+    if (msg_pub.getNumSubscribers() < 1 && msg_sub.getNumPublishers() < 1)
       ros::Duration(0.1).sleep();
     else
       break;

--- a/tests/kvaser_interface_tests.cpp
+++ b/tests/kvaser_interface_tests.cpp
@@ -1,9 +1,9 @@
 /*
-* Unpublished Copyright (c) 2009-2019 AutonomouStuff, LLC, All Rights Reserved.
-*
-* This file is part of the Kvaser ROS driver which is released under the MIT license.
-* See file LICENSE included with this software or go to https://opensource.org/licenses/MIT for full license details.
-*/
+ * Unpublished Copyright (c) 2009-2019 AutonomouStuff, LLC, All Rights Reserved.
+ *
+ * This file is part of the Kvaser ROS driver which is released under the MIT license.
+ * See file LICENSE included with this software or go to https://opensource.org/licenses/MIT for full license details.
+ */
 
 #include <kvaser_interface/kvaser_interface.h>
 #include <canstat.h>
@@ -334,7 +334,7 @@ TEST(KvaserCan, writeTests)
   ASSERT_EQ(writer_stat, ReturnStatuses::OK);
 }
 
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/tools/canmonitor.cpp
+++ b/tools/canmonitor.cpp
@@ -1,9 +1,9 @@
 /*
-* Unpublished Copyright (c) 2009-2019 AutonomouStuff, LLC, All Rights Reserved.
-*
-* This file is part of the Kvaser ROS driver which is released under the MIT license.
-* See file LICENSE included with this software or go to https://opensource.org/licenses/MIT for full license details.
-*/
+ * Unpublished Copyright (c) 2009-2019 AutonomouStuff, LLC, All Rights Reserved.
+ *
+ * This file is part of the Kvaser ROS driver which is released under the MIT license.
+ * See file LICENSE included with this software or go to https://opensource.org/licenses/MIT for full license details.
+ */
 
 #include "kvaser_interface/kvaser_interface.h"
 #include "kvaser_interface/cxxopts.h"
@@ -16,19 +16,17 @@
 #include <unistd.h>
 #include <signal.h>
 
+using AS::CAN::CanMsg;
+using AS::CAN::KvaserCan;
 using AS::CAN::KvaserCanUtils;
 using AS::CAN::KvaserChannel;
-using AS::CAN::KvaserCan;
 using AS::CAN::ReturnStatuses;
-using AS::CAN::CanMsg;
 
 KvaserCan kv_can;
 uint32_t channel_idx = 0;
 uint32_t bitrate = 500000;
 
-void shutdown(
-  const ReturnStatuses &ret = ReturnStatuses::OK,
-  const int &error_num = 0)
+void shutdown(const ReturnStatuses& ret = ReturnStatuses::OK, const int& error_num = 0)
 {
   if (ret != ReturnStatuses::OK || error_num != 0)
   {
@@ -63,8 +61,9 @@ void can_read()
       CanMsg msg;
       ret = kv_can.read(&msg);
 
-      unix_timestamp_ms = std::chrono::duration_cast<std::chrono::milliseconds>
-        (std::chrono::system_clock::now().time_since_epoch()).count();
+      unix_timestamp_ms =
+          std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch())
+              .count();
 
       if (msg.flags.error_frame)
       {
@@ -113,7 +112,7 @@ void can_read()
   }
 }
 
-int main(int argc, char ** argv)
+int main(int argc, char** argv)
 {
   // Catch CTRL+C
   struct sigaction sigIntHandler;
@@ -124,20 +123,17 @@ int main(int argc, char ** argv)
   // Parse options
   cxxopts::Options options("canmonitor", "A simple tool for reading data from a CAN channel.");
 
-  options.add_options()
-    ("i, index", "Channel index", cxxopts::value<unsigned int>()->implicit_value("0")->default_value("0"))
-    ("b, bitrate", "Bitrate", cxxopts::value<unsigned int>()->implicit_value("500000")->default_value("500000"))
-    ("h, help", "Print help", cxxopts::value<bool>()->implicit_value("true")->default_value("false"));
+  options.add_options()("i, index", "Channel index",
+                        cxxopts::value<unsigned int>()->implicit_value("0")->default_value("0"))(
+      "b, bitrate", "Bitrate", cxxopts::value<unsigned int>()->implicit_value("500000")->default_value("500000"))(
+      "h, help", "Print help", cxxopts::value<bool>()->implicit_value("true")->default_value("false"));
 
   auto result = options.parse(argc, argv);
 
   channel_idx = result["index"].as<unsigned int>();
   bitrate = result["bitrate"].as<unsigned int>();
 
-  if (channel_idx > 300 ||
-      bitrate < 100 ||
-      bitrate > 8000000 ||
-      result["help"].as<bool>())
+  if (channel_idx > 300 || bitrate < 100 || bitrate > 8000000 || result["help"].as<bool>())
   {
     std::cout << std::endl;
     std::cout << options.help();

--- a/tools/list_channels.cpp
+++ b/tools/list_channels.cpp
@@ -1,9 +1,9 @@
 /*
-* Unpublished Copyright (c) 2009-2019 AutonomouStuff, LLC, All Rights Reserved.
-*
-* This file is part of the Kvaser ROS driver which is released under the MIT license.
-* See file LICENSE included with this software or go to https://opensource.org/licenses/MIT for full license details.
-*/
+ * Unpublished Copyright (c) 2009-2019 AutonomouStuff, LLC, All Rights Reserved.
+ *
+ * This file is part of the Kvaser ROS driver which is released under the MIT license.
+ * See file LICENSE included with this software or go to https://opensource.org/licenses/MIT for full license details.
+ */
 
 #include "kvaser_interface/kvaser_interface.h"
 
@@ -13,7 +13,7 @@
 using AS::CAN::KvaserCanUtils;
 using AS::CAN::KvaserChannel;
 
-int main(int argc, char ** argv)
+int main(int argc, char** argv)
 {
   auto cards = KvaserCanUtils::getCards();
 
@@ -21,25 +21,25 @@ int main(int argc, char ** argv)
   {
     std::cout << std::endl;
 
-    for (const auto & card : cards)
+    for (const auto& card : cards)
     {
       std::cout << "Card " << (&card - &cards[0]) << ":" << std::endl;
       std::cout << "  S/N: " << card->serial_no << std::endl;
       std::cout << "  UPC: " << card->upc_no << std::endl;
       std::cout << "  Name: " << card->dev_name << std::endl;
       std::cout << "  Firmware rev: v";
-        std::cout << card->firmware_rev_maj << ".";
-        std::cout << card->firmware_rev_min << ".";
-        std::cout << card->firmware_rev_bld << std::endl;
+      std::cout << card->firmware_rev_maj << ".";
+      std::cout << card->firmware_rev_min << ".";
+      std::cout << card->firmware_rev_bld << std::endl;
       std::cout << "  Driver: " << card->driver_name << " v";
-        std::cout << card->driver_ver_maj << ".";
-        std::cout << card->driver_ver_min << ".";
-        std::cout << card->driver_ver_bld << std::endl;
+      std::cout << card->driver_ver_maj << ".";
+      std::cout << card->driver_ver_min << ".";
+      std::cout << card->driver_ver_bld << std::endl;
       std::cout << std::endl;
 
       auto channels = KvaserCanUtils::getChannelsOnCard(card->serial_no);
 
-      for (const auto & channel : channels)
+      for (const auto& channel : channels)
       {
         std::cout << "  Channel " << channel->channel_no_on_card << ":" << std::endl;
         std::cout << "    Index: " << channel->channel_idx << std::endl;


### PR DESCRIPTION
Closes #46. Uses https://github.com/davetcoleman/roscpp_code_format for auto-formatting (using current `clang-format` instead of 3.8 as recommended there). Rather than including the file here, it makes more sense to host a copy at the base of your workspace. Had to manually disable/enable `clang-format` on the `extern "C"` line due to a conflict between `roslint` and `clang-format`.