### PR TITLE
Fix static function callback woes

### DIFF
--- a/include/kvaser_interface/kvaser_interface.h
+++ b/include/kvaser_interface/kvaser_interface.h
@@ -37,7 +37,8 @@ enum class ReturnStatuses
   READ_FAILED = -6,
   WRITE_FAILED = -7,
   CLOSE_FAILED = -8,
-  DLC_PAYLOAD_MISMATCH = -9
+  DLC_PAYLOAD_MISMATCH = -9,
+  CALLBACK_REGISTRATION_FAILED = -10
 };
 
 enum class HardwareType
@@ -265,17 +266,7 @@ private:
   bool on_bus;
 };
 
-class KvaserReadCbProxy
-{
-public:
-  static ReturnStatuses registerCb(KvaserCan* canObj, const std::shared_ptr<CanHandle>& hdl);
-
-private:
-  static void proxyCallback(canNotifyData* data);
-
-  static KvaserCan* kvCanObj;
-  static std::shared_ptr<CanHandle> handle;
-};
+void proxyCallback(canNotifyData* data);
 
 class KvaserCanUtils
 {


### PR DESCRIPTION
See #50 for context and explanation. Now calling `canSetNotify()` from [the Canlib API](https://www.kvaser.com/canlib-webhelp/group___c_a_n.html#ga7d2b3b2381f355b0fa4a0a561068bcdb) with an instance of the current KvaserCan object cast to a `void*` as the `tag` argument. This then gets returned to the callback proxy function as the `tag` field of a `canNotifyData` struct. This is then cast back to a KvaserCan object in order to call the user-defined read callback.

Do not merge until tested on a sensor and a vehicle.

- [x] Vehicle testing with PACMod complete.
- [x] Sensor testing complete.