### PR TITLE
Edit README for install instructions on kernel 5.13+

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ sudo apt update
 sudo apt install kvaser-canlib-dev kvaser-drivers-dkms
 ```
 
+For kernel versions 5.13+ the Kvaser drivers are broken.  They require a header file which is no longer included in new kernels.
+This can be fixed by first running:
+
+```sh
+sudo touch /usr/src/linux-headers-`uname -r`/include/config/modversions.h
+```
+
 Now that the dependencies are installed, we can install `kvaser_interface`:
 
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ sudo apt update
 sudo apt install kvaser-canlib-dev kvaser-drivers-dkms
 ```
 
+For kernel versions 5.13+ the Kvaser drivers are broken.  They require a header file which is no longer included in new kernels.
+This can be fixed by first running:
+
+```sh
+sudo touch /usr/src/linux-headers-`uname -r`/include/config
+```
+
 Now that the dependencies are installed, we can install `kvaser_interface`:
 
 


### PR DESCRIPTION
Kernel no longer includes <config/modversions.h>, which is required by the Kvaser driver.  This header file has been an empty file, at least since 4.4, but was outright removed in 5.13.  I have fixed this issue in the driver source code, but Kvaser does not have a repo to contribute to.  This fix will allow the driver and the kvaser_interface package to be installed.