### PR TITLE
fix: initialize boolean variable

### DIFF
--- a/include/kvaser_interface/kvaser_interface.hpp
+++ b/include/kvaser_interface/kvaser_interface.hpp
@@ -307,7 +307,7 @@ public:
 
 private:
   std::shared_ptr<CanHandle> handle;
-  bool on_bus;
+  bool on_bus = false;
 };
 
 void proxyCallback(canNotifyData * data);


### PR DESCRIPTION
The behavior of kvaser_interface was unstable because there was an uninitialized boolean variable.
I fixed it.

( 
In original kvaser_interface, sometimes the following error messages are output in large numbers even though there is no problem with the connection of the kvaser device.
`Tried to write CAN message but writer was closed.`
)

