### PR TITLE
ROS1: Update circleci container

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ commands:
           name: Clone and Run AS Docker Image
           command: |
             docker pull << parameters.docker_image >>
-            docker run -d --name test --device=/dev/kvvirtualcan0 --device=/dev/kvvirtualcan1 --device=/dev/kvvirtualcan2 --device=/dev/kvvirtualcan3 --device=/dev/kvvirtualcan4 --device=/dev/kvvirtualcan5 -v `pwd`:/ros_ws/src -w /ros_ws << parameters.docker_image >> sh -c "sleep infinity"
+            docker run -d --name test --device=/dev/kvvirtualcan0 --device=/dev/kvvirtualcan1 -v `pwd`:/ros_ws/src -w /ros_ws << parameters.docker_image >> sh -c "sleep infinity"
       - run:
           name: Install Linuxcan in Docker
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ commands:
 jobs:
   melodic:
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-2004:202111-02
     steps:
       - ros_build:
           docker_image: autonomoustuff/docker-builds:melodic-ros-base
@@ -60,7 +60,7 @@ jobs:
 
   noetic:
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-2004:202111-02
     steps:
       - ros_build:
           docker_image: autonomoustuff/docker-builds:noetic-ros-base

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,12 +19,13 @@ commands:
             sudo sed -i 's/#define NR_VIRTUAL_DEV       1/#define NR_VIRTUAL_DEV       3/g' virtualcan/virtualcan.h
             sudo make virtualcan
             sudo install -m 644 virtualcan/kvvirtualcan.ko /lib/modules/`uname -r`/updates/dkms/
+            sudo virtualcan.sh stop
             sudo virtualcan.sh start
       - run:
           name: Clone and Run AS Docker Image
           command: |
             docker pull << parameters.docker_image >>
-            docker run -d --name test --device=/dev/kvvirtualcan0 --device=/dev/kvvirtualcan1 -v `pwd`:/ros_ws/src -w /ros_ws << parameters.docker_image >> sh -c "sleep infinity"
+            docker run -d --name test --device=/dev/kvvirtualcan0 --device=/dev/kvvirtualcan1 --device=/dev/kvvirtualcan2 --device=/dev/kvvirtualcan3 --device=/dev/kvvirtualcan4 --device=/dev/kvvirtualcan5 -v `pwd`:/ros_ws/src -w /ros_ws << parameters.docker_image >> sh -c "sleep infinity"
       - run:
           name: Install Linuxcan in Docker
           command: |


### PR DESCRIPTION
Resolves #79 by updating the ubuntu container used for CI. The old containers are being deprecated soon.

I had to an the `sudo virtualcan.sh stop` since it seems the latest version of kvaser-dkms starts up the virtualcan channels automatically during installation. Stopping and starting allows the virtualcan changes to take effect.