### PR TITLE
implement silent mode

### DIFF
--- a/include/kvaser_interface/kvaser_interface.h
+++ b/include/kvaser_interface/kvaser_interface.h
@@ -262,7 +262,7 @@ public:
   std::function<void(void)> readFunc;
 
   // Set output mode to silent
-  void set_silent_mode(bool _silent_mode);
+  void setSilentMode(bool _silent_mode);
 
 private:
   std::shared_ptr<CanHandle> handle;

--- a/include/kvaser_interface/kvaser_interface.h
+++ b/include/kvaser_interface/kvaser_interface.h
@@ -261,9 +261,13 @@ public:
   // Read callback function
   std::function<void(void)> readFunc;
 
+  // Set output mode to silent
+  void set_silent_mode(bool _silent_mode);
+
 private:
   std::shared_ptr<CanHandle> handle;
   bool on_bus = false;
+  bool silent_mode = false;
 };
 
 void proxyCallback(canNotifyData* data);

--- a/src/kvaser_interface.cpp
+++ b/src/kvaser_interface.cpp
@@ -602,7 +602,7 @@ void KvaserCanUtils::setFlagsFromMsg(const CanMsg& msg, uint32_t* flags)
   msg.error_flags.bit1_err ? * flags |= canMSGERR_BIT1 : * flags &= ~canMSGERR_BIT1;
 }
 
-void KvaserCan::set_silent_mode(bool _silent_mode)
+void KvaserCan::setSilentMode(bool _silent_mode)
 {
   silent_mode = _silent_mode;
 }

--- a/src/kvaser_interface.cpp
+++ b/src/kvaser_interface.cpp
@@ -111,7 +111,14 @@ ReturnStatuses KvaserCan::open(const uint32_t& channel_index, const uint32_t& bi
     }
 
     // Set output control
-    canSetBusOutputControl(*handle, canDRIVER_NORMAL);
+    if (silent_mode)
+    {
+      canSetBusOutputControl(*handle, canDRIVER_SILENT);
+    }
+    else
+    {
+      canSetBusOutputControl(*handle, canDRIVER_NORMAL);
+    }
 
     if (canBusOn(*handle) < 0)
       return ReturnStatuses::INIT_FAILED;
@@ -593,4 +600,9 @@ void KvaserCanUtils::setFlagsFromMsg(const CanMsg& msg, uint32_t* flags)
   msg.error_flags.crc_err ? * flags |= canMSGERR_CRC : * flags &= ~canMSGERR_CRC;
   msg.error_flags.bit0_err ? * flags |= canMSGERR_BIT0 : * flags &= ~canMSGERR_BIT0;
   msg.error_flags.bit1_err ? * flags |= canMSGERR_BIT1 : * flags &= ~canMSGERR_BIT1;
+}
+
+void KvaserCan::set_silent_mode(bool _silent_mode)
+{
+  silent_mode = _silent_mode;
 }


### PR DESCRIPTION
Implemented setting the output control mode to Silent for situations that require it.  Uses a setter method to set a flag that defaults to false.  Calls to open method are unaffected.  To use, call set_silent_mode(true) before calling open.  